### PR TITLE
docs: Clarify Nexus Premium is recommended, not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ bun run build && bun run package
 This builds the renderer to `dist/` and packages the Electron app (using electron-builder).
 
 ## Nexus Mods API Key
-- You must have a Nexus Mods API key (Premium).
+- You need a Nexus Mods API key (Premium membership recommended for higher rate limits).
 - Open Settings in the app and paste your API key.
 - Key is stored locally via `electron-store`.
 


### PR DESCRIPTION
This PR updates the README to clarify that Nexus Premium membership is recommended for higher API rate limits but is not strictly required to use the Nexus Mods API.

## Changes
- Updated the Nexus Mods API Key section in README.md
- Changed from 'You must have' to 'You need' with clarification about Premium being recommended but not required

This provides more accurate information to users about the API requirements.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/9fa2156d-5a48-4110-b53c-a58ab784b1b8/task/4cdf98f2-4aa2-4c00-a1f8-2a331479e7a4))