### PR TITLE
fix: add @react-spring/web to resolve react-tinder-card optional peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint . || true"
   },
   "dependencies": {
+    "@react-spring/web": "^9.7.2",
     "axios": "^1.7.2",
     "cheerio": "^1.0.0-rc.12",
     "compromise": "^14.14.2",


### PR DESCRIPTION
This PR adds @react-spring/web to dependencies.\n\nWithout it, the renderer fails during dev with: \n\n> Uncaught Error: Could not resolve '@react-spring/web' imported by 'react-tinder-card'\n\nAdding the library satisfies the optional peer import that Vite attempts to bundle. No code changes required.\n\nTested by running dev and verifying the Electron window renders the swipe UI.